### PR TITLE
Add kwargs support for ini fileConfig

### DIFF
--- a/ExtendedJournalHandler/__init__.py
+++ b/ExtendedJournalHandler/__init__.py
@@ -4,6 +4,22 @@ JOURNAL_KEY_PREFIX = "JOURNAL_"
 
 
 class ExtendedJournalHandler(JournalHandler):
+    def __init__(self, *args, **kwargs):
+        """logging.config.fileConfig does not support kwargs
+
+        see https://bugs.python.org/issue31080
+
+        so let's use last args parameter to update kwargs dict
+        and we still can use args to pass positional arguments
+
+        [handler_journal]
+        class = ExtendedJournalHandler.ExtendedJournalHandler
+        args = (INFO, {"SYSLOG_IDENTIFIER":"my-cool-app"})
+        """
+        if args and isinstance(args[-1], dict):
+            kwargs.update(args[-1])
+            args = args[:-1]
+        super(ExtendedJournalHandler, self).__init__(*args, **kwargs)
 
     def emit(self, record):
         """Write record as journal event.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.0'
+version = '1.1.0'
 
 setup(name='ExtendedJournalHandler',
       version=version,


### PR DESCRIPTION
Налаштування в ini файлах не підтримують kwargs і не дозволяють передати SYSLOG_IDENTIFIER. Цей патч додає можливість передавати ці налаштування через args.